### PR TITLE
move parse error handling into `parse/` package

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -5,19 +5,12 @@
 package api
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"os"
-	"strings"
 	"time"
-
-	"gopkg.in/yaml.v3"
 )
 
 var (
-	// ErrParse indicates a YAML definition is not valid
-	ErrParse = errors.New("parse error")
 	// ErrUnknownField indicates that there was an unknown field in the parsing
 	// of a spec or scenario.
 	ErrUnknownField = errors.New("unknown field")
@@ -104,215 +97,16 @@ func UnexpectedError(err error) error {
 	return fmt.Errorf("%w: %s", ErrUnexpectedError, err)
 }
 
-// ParseError is a custom error type that stores the location of an error that
-// occurred while parsing a gdt test specification.
-type ParseError struct {
-	// Path is the filepath to the parsed document.
-	Path string
-	// Line is the line number where the parse error occurred.
-	Line int
-	// Column is the column number where the parse error occurred.
-	Column int
-	// Message is the error message.
-	Message string
-	// Contents is the contents of the file read at Path.
-	Contents string
-}
-
-// Error implements the error interface for ParseError.
-func (e *ParseError) Error() string {
-	contents := ""
-	if e.Contents != "" {
-		contents = fmt.Sprintf("\n%s\n", e.Contents)
-	}
-	return fmt.Sprintf(
-		"error parsing %q: at line %d, column %d:\n%s\n%s",
-		e.Path, e.Line, e.Column, e.Message, contents,
-	)
-}
-
-// SetContents adds the detail to the error message for surrounding contents if
-// the Path, Line and Column is set.
-func (e *ParseError) SetContents() {
-	if e.Path != "" {
-		f, err := os.Open(e.Path)
-		if err != nil {
-			// just ignore...
-			return
-		}
-		defer f.Close()
-
-		b := &strings.Builder{}
-		viewStartLine := max(0, e.Line-2)
-		viewEndLine := e.Line + 2
-
-		sc := bufio.NewScanner(f)
-		x := 0
-		for sc.Scan() {
-			x++
-			line := sc.Text()
-			if x > viewEndLine {
-				break
-			}
-			if x < viewStartLine {
-				continue
-			}
-			_, _ = fmt.Fprintf(b, "%03d: %s\n", x, line)
-			if x == e.Line {
-				_, _ = fmt.Fprintf(b, "  %s^", strings.Repeat(" ", e.Column))
-			}
-		}
-		if err := sc.Err(); err != nil {
-			// just ignore...
-			return
-		}
-		e.Contents = b.String()
-	}
-}
-
-func (e *ParseError) Unwrap() error {
-	return ErrParse
-}
-
 var (
 	// ErrUnknownSourceType indicates that a From() function was called with an
 	// unknown source parameter type.
 	ErrUnknownSourceType = errors.New("unknown source argument type")
 )
 
-// UnknownSpecAt returns an ErrUnknownSpec with the line/column of the supplied
-// YAML node.
-func UnknownSpecAt(path string, node *yaml.Node) error {
-	return &ParseError{
-		Path:    path,
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "no plugin could parse spec definition",
-	}
-}
-
-// UnknownFieldAt returns an ErrUnknownField for a supplied field annotated
-// with the line/column of the supplied YAML node.
-func UnknownFieldAt(field string, node *yaml.Node) error {
-	return fmt.Errorf(
-		"%w: %q at line %d, column %d",
-		ErrUnknownField, field, node.Line, node.Column,
-	)
-}
-
-// ExpectedMapAt returns an ErrExpectedMap error annotated with the
-// line/column of the supplied YAML node.
-func ExpectedMapAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected map field",
-	}
-}
-
-// ExpectedScalarAt returns an ErrExpectedScalar error annotated with
-// the line/column of the supplied YAML node.
-func ExpectedScalarAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected scalar field",
-	}
-}
-
-// ExpectedSequenceAt returns an ErrExpectedSequence error annotated
-// with the line/column of the supplied YAML node.
-func ExpectedSequenceAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected sequence field",
-	}
-}
-
-// ExpectedIntAt returns an ErrExpectedInt error annotated
-// with the line/column of the supplied YAML node.
-func ExpectedIntAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected int value",
-	}
-}
-
-// ExpectedScalarOrSequenceAt returns an ErrExpectedScalarOrSequence error
-// annotated with the line/column of the supplied YAML node.
-func ExpectedScalarOrSequenceAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected scalar or sequence of scalars field",
-	}
-}
-
-// ExpectedScalarOrMapAt returns an ErrExpectedScalarOrMap error annotated with
-// the line/column of the supplied YAML node.
-func ExpectedScalarOrMapAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected scalar or map field",
-	}
-}
-
-// ExpectedTimeoutAt returns an ErrExpectedTimeout error annotated
-// with the line/column of the supplied YAML node.
-func ExpectedTimeoutAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected timeout specification",
-	}
-}
-
-// ExpectedWaitAt returns an ErrExpectedWait error annotated with the
-// line/column of the supplied YAML node.
-func ExpectedWaitAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected wait specification",
-	}
-}
-
-// ExpectedRetryAt returns an ErrExpectedRetry error annotated with the
-// line/column of the supplied YAML node.
-func ExpectedRetryAt(node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected retry specification",
-	}
-}
-
-// InvalidRetryAttempts returns an ErrInvalidRetryAttempts error annotated with
-// the line/column of the supplied YAML node.
-func InvalidRetryAttempts(node *yaml.Node, attempts int) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("invalid retry attempts: %d", attempts),
-	}
-}
-
 // UnknownSourceType returns an ErrUnknownSourceType error describing the
 // supplied parameter type.
 func UnknownSourceType(source interface{}) error {
 	return fmt.Errorf("%w: %T", ErrUnknownSourceType, source)
-}
-
-// FileNotFound returns ErrFileNotFound for a given file path
-func FileNotFound(path string, node *yaml.Node) error {
-	return &ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("file not found: %q", path),
-	}
 }
 
 var (

--- a/api/flexstrings.go
+++ b/api/flexstrings.go
@@ -6,6 +6,8 @@ package api
 
 import (
 	"gopkg.in/yaml.v3"
+
+	"github.com/gdt-dev/core/parse"
 )
 
 // FlexStrings is a struct used to parse an interface{} that can be either a
@@ -23,7 +25,7 @@ func (f *FlexStrings) Values() []string {
 // FlexStrings can be either a string or a slice of strings.
 func (f *FlexStrings) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.ScalarNode && node.Kind != yaml.SequenceNode {
-		return ExpectedScalarOrSequenceAt(node)
+		return parse.ExpectedScalarOrSequenceAt(node)
 	}
 	var single string
 	if err := node.Decode(&single); err == nil {
@@ -35,5 +37,5 @@ func (f *FlexStrings) UnmarshalYAML(node *yaml.Node) error {
 		f.values = many
 		return nil
 	}
-	return ExpectedScalarOrSequenceAt(node)
+	return parse.ExpectedScalarOrSequenceAt(node)
 }

--- a/api/flexstrings_test.go
+++ b/api/flexstrings_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/parse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -30,7 +31,7 @@ func TestFlexStringsError(t *testing.T) {
 	err := yaml.Unmarshal(contents, &f)
 
 	require.NotNil(err)
-	assert.ErrorIs(err, api.ErrParse)
+	assert.Error(err, &parse.Error{})
 }
 
 func TestFlexStrings(t *testing.T) {

--- a/assertion/json/errors.go
+++ b/assertion/json/errors.go
@@ -8,63 +8,7 @@ import (
 	"fmt"
 
 	"github.com/gdt-dev/core/api"
-	"gopkg.in/yaml.v3"
 )
-
-// UnsupportedJSONSchemaReference returns ErrUnsupportedJSONSchemaReference for
-// a supplied URL.
-func UnsupportedJSONSchemaReference(url string, node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("unsupported JSONSchema reference: %s", url),
-	}
-}
-
-// JSONSchemaFileNotFound returns ErrJSONSchemaFileNotFound for a supplied
-// path.
-func JSONSchemaFileNotFound(path string, node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("unable to find JSONSchema file %q", path),
-	}
-}
-
-// JSONUnmarshalError returns an ErrFailure when JSON content cannot be
-// decoded.
-func JSONUnmarshalError(err error, node *yaml.Node) error {
-	if node != nil {
-		return &api.ParseError{
-			Line:    node.Line,
-			Column:  node.Column,
-			Message: fmt.Sprintf("failed to unmarshal JSON: %s", err),
-		}
-	}
-	return &api.ParseError{
-		Message: fmt.Sprintf("failed to unmarshal JSON: %s", err),
-	}
-}
-
-// JSONPathInvalid returns an ParseError when a JSONPath expression could not be
-// parsed.
-func JSONPathInvalid(path string, err error, node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("JSONPath invalid: %s: %s", path, err),
-	}
-}
-
-// JSONPathInvalidNoRoot returns an ErrJSONPathInvalidNoRoot when a JSONPath
-// expression does not start with '$'.
-func JSONPathInvalidNoRoot(path string, node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("JSONPath expression %s invalid: expression must start with '$'", path),
-	}
-}
 
 var (
 	// ErrJSONPathNotFound returns an ErrFailure when a JSONPath expression

--- a/assertion/json/json_test.go
+++ b/assertion/json/json_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gdt-dev/core/api"
 	gdtjson "github.com/gdt-dev/core/assertion/json"
+	"github.com/gdt-dev/core/parse"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -27,7 +28,7 @@ schema: http://example.com/schema
 `)
 	err := yaml.Unmarshal(content, &exp)
 	require.NotNil(err)
-	require.ErrorIs(err, api.ErrParse)
+	require.Error(err, &parse.Error{})
 }
 
 func TestJSONSchemaFileNotFound(t *testing.T) {
@@ -40,7 +41,7 @@ schema: file:///path/does/not/exist
 `)
 	err := yaml.Unmarshal(content, &exp)
 	require.NotNil(err)
-	require.ErrorIs(err, api.ErrParse)
+	require.Error(err, &parse.Error{})
 }
 
 func TestJSONPathInvalid(t *testing.T) {
@@ -61,7 +62,7 @@ paths: notamap
 `)
 	err = yaml.Unmarshal(content, &exp)
 	require.NotNil(err)
-	require.ErrorIs(err, api.ErrParse)
+	require.Error(err, &parse.Error{})
 
 	content = []byte(`
 len: 1
@@ -70,7 +71,7 @@ paths:
 `)
 	err = yaml.Unmarshal(content, &exp)
 	require.NotNil(err)
-	require.ErrorIs(err, api.ErrParse)
+	require.Error(err, &parse.Error{})
 
 	content = []byte(`
 len: 1
@@ -79,7 +80,7 @@ paths:
 `)
 	err = yaml.Unmarshal(content, &exp)
 	require.NotNil(err)
-	require.ErrorIs(err, api.ErrParse)
+	require.Error(err, &parse.Error{})
 
 	content = []byte(`
 len: 1
@@ -88,7 +89,7 @@ paths:
 `)
 	err = yaml.Unmarshal(content, &exp)
 	require.NotNil(err)
-	require.ErrorIs(err, api.ErrParse)
+	require.Error(err, &parse.Error{})
 }
 
 func content() []byte {
@@ -135,7 +136,7 @@ func TestJSONUnmarshalError(t *testing.T) {
 	require.False(a.OK(ctx))
 	failures := a.Failures()
 	require.Len(failures, 1)
-	require.ErrorIs(failures[0], api.ErrParse)
+	require.Error(failures[0], &parse.Error{})
 }
 
 func TestJSONPathError(t *testing.T) {

--- a/assertion/json/parse.go
+++ b/assertion/json/parse.go
@@ -1,0 +1,171 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package json
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/PaesslerAG/jsonpath"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gdt-dev/core/parse"
+)
+
+var (
+	// defining the JSONPath language here allows us to disaggregate parse
+	// errors from runtime errors when evaluating a JSONPath expression.
+	lang = jsonpath.Language()
+)
+
+// UnsupportedJSONSchemaReference returns ErrUnsupportedJSONSchemaReference for
+// a supplied URL.
+func UnsupportedJSONSchemaReference(url string, node *yaml.Node) error {
+	return &parse.Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: fmt.Sprintf("unsupported JSONSchema reference: %s", url),
+	}
+}
+
+// JSONSchemaFileNotFound returns ErrJSONSchemaFileNotFound for a supplied
+// path.
+func JSONSchemaFileNotFound(path string, node *yaml.Node) error {
+	return &parse.Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: fmt.Sprintf("unable to find JSONSchema file %q", path),
+	}
+}
+
+// JSONUnmarshalError returns an ErrFailure when JSON content cannot be
+// decoded.
+func JSONUnmarshalError(err error, node *yaml.Node) error {
+	if node != nil {
+		return &parse.Error{
+			Line:    node.Line,
+			Column:  node.Column,
+			Message: fmt.Sprintf("failed to unmarshal JSON: %s", err),
+		}
+	}
+	return &parse.Error{
+		Message: fmt.Sprintf("failed to unmarshal JSON: %s", err),
+	}
+}
+
+// JSONPathInvalid returns an ParseError when a JSONPath expression could not be
+// parsed.
+func JSONPathInvalid(path string, err error, node *yaml.Node) error {
+	return &parse.Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: fmt.Sprintf("JSONPath invalid: %s: %s", path, err),
+	}
+}
+
+// JSONPathInvalidNoRoot returns an ErrJSONPathInvalidNoRoot when a JSONPath
+// expression does not start with '$'.
+func JSONPathInvalidNoRoot(path string, node *yaml.Node) error {
+	return &parse.Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: fmt.Sprintf("JSONPath expression %s invalid: expression must start with '$'", path),
+	}
+}
+
+// UnmarshalYAML is a custom unmarshaler that ensures that JSONPath expressions
+// contained in the Expect are valid.
+func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return parse.ExpectedMapAt(node)
+	}
+	// maps/structs are stored in a top-level Node.Content field which is a
+	// concatenated slice of Node pointers in pairs of key/values.
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		if keyNode.Kind != yaml.ScalarNode {
+			return parse.ExpectedScalarAt(keyNode)
+		}
+		key := keyNode.Value
+		valNode := node.Content[i+1]
+		switch key {
+		case "len":
+			if valNode.Kind != yaml.ScalarNode {
+				return parse.ExpectedScalarAt(valNode)
+			}
+			var v *int
+			if err := valNode.Decode(&v); err != nil {
+				return err
+			}
+			e.Len = v
+		case "schema":
+			if valNode.Kind != yaml.ScalarNode {
+				return parse.ExpectedScalarAt(valNode)
+			}
+			// Ensure any JSONSchema URL specified in exponse.json.schema exists
+			schemaURL := valNode.Value
+			if strings.HasPrefix(schemaURL, "http://") || strings.HasPrefix(schemaURL, "https://") {
+				// TODO(jaypipes): Support network lookups?
+				return UnsupportedJSONSchemaReference(schemaURL, valNode)
+			}
+			// Convert relative filepaths to absolute filepaths rooted in the context's
+			// testdir after stripping any "file://" scheme prefix
+			schemaURL = strings.TrimPrefix(schemaURL, "file://")
+			schemaURL, _ = filepath.Abs(schemaURL)
+
+			f, err := os.Open(schemaURL)
+			if err != nil {
+				return JSONSchemaFileNotFound(schemaURL, valNode)
+			}
+			defer f.Close()
+			if runtime.GOOS == "windows" {
+				// Need to do this because of an "optimization" done in the
+				// gojsonreference library:
+				// https://github.com/xeipuuv/gojsonreference/blob/bd5ef7bd5415a7ac448318e64f11a24cd21e594b/reference.go#L107-L114
+				e.Schema = "file:///" + schemaURL
+			} else {
+				e.Schema = "file://" + schemaURL
+			}
+		case "paths":
+			if valNode.Kind != yaml.MappingNode {
+				return parse.ExpectedMapAt(valNode)
+			}
+			paths := map[string]string{}
+			if err := valNode.Decode(&paths); err != nil {
+				return err
+			}
+			for path := range paths {
+				if len(path) == 0 || path[0] != '$' {
+					return JSONPathInvalidNoRoot(path, valNode)
+				}
+				if _, err := lang.NewEvaluable(path); err != nil {
+					return JSONPathInvalid(path, err, valNode)
+				}
+			}
+			e.Paths = paths
+		case "path_formats", "path-formats":
+			if valNode.Kind != yaml.MappingNode {
+				return parse.ExpectedMapAt(valNode)
+			}
+			pathFormats := map[string]string{}
+			if err := valNode.Decode(&pathFormats); err != nil {
+				return err
+			}
+			for pathFormat := range pathFormats {
+				if len(pathFormat) == 0 || pathFormat[0] != '$' {
+					return JSONPathInvalidNoRoot(pathFormat, valNode)
+				}
+				if _, err := lang.NewEvaluable(pathFormat); err != nil {
+					return JSONPathInvalid(pathFormat, err, valNode)
+				}
+			}
+			e.PathFormats = pathFormats
+		}
+	}
+	return nil
+}

--- a/internal/testutil/plugin/bar/plugin.go
+++ b/internal/testutil/plugin/bar/plugin.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/parse"
 	"github.com/gdt-dev/core/plugin"
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
@@ -58,24 +59,24 @@ func (s *Spec) Eval(context.Context) (*api.Result, error) {
 
 func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "bar":
 			if valNode.Kind != yaml.ScalarNode {
-				return api.ExpectedScalarAt(valNode)
+				return parse.ExpectedScalarAt(valNode)
 			}
 			if v, err := strconv.Atoi(valNode.Value); err != nil {
-				return api.ExpectedIntAt(valNode)
+				return parse.ExpectedIntAt(valNode)
 			} else {
 				s.Bar = v
 			}
@@ -83,7 +84,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 			if lo.Contains(api.BaseSpecFields, key) {
 				continue
 			}
-			return api.UnknownFieldAt(key, keyNode)
+			return parse.UnknownFieldAt(key, keyNode)
 		}
 	}
 	return nil

--- a/internal/testutil/plugin/failer/plugin.go
+++ b/internal/testutil/plugin/failer/plugin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gdt-dev/core/api"
 	gdtapi "github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/parse"
 	"github.com/gdt-dev/core/plugin"
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
@@ -30,21 +31,21 @@ type Defaults struct {
 
 func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "fail":
 			if valNode.Kind != yaml.MappingNode {
-				return api.ExpectedMapAt(valNode)
+				return parse.ExpectedMapAt(valNode)
 			}
 			inner := InnerDefaults{}
 			if err := valNode.Decode(&inner); err != nil {
@@ -89,21 +90,21 @@ func (s *Spec) Eval(context.Context) (*api.Result, error) {
 
 func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "fail":
 			if valNode.Kind != yaml.ScalarNode {
-				return api.ExpectedScalarAt(valNode)
+				return parse.ExpectedScalarAt(valNode)
 			}
 			s.Fail, _ = strconv.ParseBool(valNode.Value)
 			if s.Fail {
@@ -113,7 +114,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 			if lo.Contains(api.BaseSpecFields, key) {
 				continue
 			}
-			return api.UnknownFieldAt(key, keyNode)
+			return parse.UnknownFieldAt(key, keyNode)
 		}
 	}
 	return nil

--- a/internal/testutil/plugin/foo/plugin.go
+++ b/internal/testutil/plugin/foo/plugin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gdt-dev/core/api"
 	"github.com/gdt-dev/core/debug"
+	"github.com/gdt-dev/core/parse"
 	"github.com/gdt-dev/core/plugin"
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
@@ -34,21 +35,21 @@ type Defaults struct {
 
 func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "foo":
 			if valNode.Kind != yaml.MappingNode {
-				return api.ExpectedMapAt(valNode)
+				return parse.ExpectedMapAt(valNode)
 			}
 			inner := InnerDefaults{}
 			if err := valNode.Decode(&inner); err != nil {
@@ -85,28 +86,28 @@ func (s *Spec) Timeout() *api.Timeout {
 
 func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "foo":
 			if valNode.Kind != yaml.ScalarNode {
-				return api.ExpectedScalarAt(valNode)
+				return parse.ExpectedScalarAt(valNode)
 			}
 			s.Foo = valNode.Value
 		default:
 			if lo.Contains(api.BaseSpecFields, key) {
 				continue
 			}
-			return api.UnknownFieldAt(key, keyNode)
+			return parse.UnknownFieldAt(key, keyNode)
 		}
 	}
 	return nil

--- a/internal/testutil/plugin/priorrun/plugin.go
+++ b/internal/testutil/plugin/priorrun/plugin.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gdt-dev/core/api"
 	gdtcontext "github.com/gdt-dev/core/context"
+	"github.com/gdt-dev/core/parse"
 	"github.com/gdt-dev/core/plugin"
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
@@ -51,33 +52,33 @@ func (s *Spec) Timeout() *api.Timeout {
 
 func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "state":
 			if valNode.Kind != yaml.ScalarNode {
-				return api.ExpectedScalarAt(valNode)
+				return parse.ExpectedScalarAt(valNode)
 			}
 			s.State = valNode.Value
 		case "prior":
 			if valNode.Kind != yaml.ScalarNode {
-				return api.ExpectedScalarAt(valNode)
+				return parse.ExpectedScalarAt(valNode)
 			}
 			s.Prior = valNode.Value
 		default:
 			if lo.Contains(api.BaseSpecFields, key) {
 				continue
 			}
-			return api.UnknownFieldAt(key, keyNode)
+			return parse.UnknownFieldAt(key, keyNode)
 		}
 	}
 	return nil

--- a/parse/error.go
+++ b/parse/error.go
@@ -1,0 +1,229 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package parse
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	// ErrParseUnknownField indicates that there was an unknown field in the
+	// parsing of a spec or scenario. This is a sentinel error we use in
+	// parsing gdt test scenarios in the plugin system.
+	ErrParseUnknownField = errors.New("unknown field")
+)
+
+// Error is a custom error type that stores the location of an error that
+// occurred while parsing a gdt test specification.
+type Error struct {
+	// Path is the filepath to the parsed document.
+	Path string
+	// Line is the line number where the parse error occurred.
+	Line int
+	// Column is the column number where the parse error occurred.
+	Column int
+	// Message is the error message.
+	Message string
+	// Contents is the contents of the file read at Path.
+	Contents string
+}
+
+// Error implements the error interface for Error.
+func (e *Error) Error() string {
+	contents := ""
+	if e.Contents != "" {
+		contents = fmt.Sprintf("\n%s\n", e.Contents)
+	}
+	return fmt.Sprintf(
+		"error parsing %q: at line %d, column %d:\n%s\n%s",
+		e.Path, e.Line, e.Column, e.Message, contents,
+	)
+}
+
+// SetContents adds the detail to the error message for surrounding contents if
+// the Path, Line and Column is set.
+func (e *Error) SetContents() {
+	if e.Path != "" {
+		f, err := os.Open(e.Path)
+		if err != nil {
+			// just ignore...
+			return
+		}
+		defer f.Close()
+
+		b := &strings.Builder{}
+		viewStartLine := max(0, e.Line-2)
+		viewEndLine := e.Line + 2
+
+		sc := bufio.NewScanner(f)
+		x := 0
+		for sc.Scan() {
+			x++
+			line := sc.Text()
+			if x > viewEndLine {
+				break
+			}
+			if x < viewStartLine {
+				continue
+			}
+			_, _ = fmt.Fprintf(b, "%03d: %s\n", x, line)
+			if x == e.Line {
+				_, _ = fmt.Fprintf(b, "  %s^", strings.Repeat(" ", e.Column))
+			}
+		}
+		if err := sc.Err(); err != nil {
+			// just ignore...
+			return
+		}
+		e.Contents = b.String()
+	}
+}
+
+// UnknownSpecAt returns an ErrUnknownSpec with the line/column of the supplied
+// YAML node.
+func UnknownSpecAt(path string, node *yaml.Node) error {
+	return &Error{
+		Path:    path,
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "no plugin could parse spec definition",
+	}
+}
+
+// UnknownFieldAt returns an ErrUnknownField for a supplied field annotated
+// with the line/column of the supplied YAML node.
+func UnknownFieldAt(field string, node *yaml.Node) error {
+	return fmt.Errorf(
+		"%w: %q at line %d, column %d",
+		ErrParseUnknownField, field, node.Line, node.Column,
+	)
+}
+
+// ExpectedMapAt returns a parse error for when a field that can contain a
+// map[string]interface{} did not contain that.
+func ExpectedMapAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected map field",
+	}
+}
+
+// ErrExpectedMapOrYAMLString returns a parse error for when a field that can
+// contain a map[string]interface{} or an embedded YAML string did not contain
+// either of those things.
+func ErrExpectedMapOrYAMLString(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected either map[string]interface{} or a string with embedded YAML",
+	}
+}
+
+// ExpectedScalarAt returns an ErrExpectedScalar error annotated with
+// the line/column of the supplied YAML node.
+func ExpectedScalarAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected scalar field",
+	}
+}
+
+// ExpectedSequenceAt returns a parse error for when a field that can contain a
+// []interface{} did not contain that.
+func ExpectedSequenceAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected sequence field",
+	}
+}
+
+// ExpectedSequenceAt returns a parse error for when a field that can contain an
+// integer did not contain that.
+func ExpectedIntAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected int value",
+	}
+}
+
+// ErrExpectedScalarOrSequenceAt returns a parse error for when a field that
+// can contain either a scalar or a []interface{} did not contain either of
+// those things.
+func ExpectedScalarOrSequenceAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected scalar or sequence of scalars field",
+	}
+}
+
+// ExpectedScalarOrMapAt returns an ErrExpectedScalarOrMap error annotated with
+// the line/column of the supplied YAML node.
+func ExpectedScalarOrMapAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected scalar or map field",
+	}
+}
+
+// ExpectedTimeoutAt returns an ErrExpectedTimeout error annotated
+// with the line/column of the supplied YAML node.
+func ExpectedTimeoutAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected timeout specification",
+	}
+}
+
+// ExpectedWaitAt returns an ErrExpectedWait error annotated with the
+// line/column of the supplied YAML node.
+func ExpectedWaitAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected wait specification",
+	}
+}
+
+// ExpectedRetryAt returns an ErrExpectedRetry error annotated with the
+// line/column of the supplied YAML node.
+func ExpectedRetryAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected retry specification",
+	}
+}
+
+// InvalidRetryAttempts returns an ErrInvalidRetryAttempts error annotated with
+// the line/column of the supplied YAML node.
+func InvalidRetryAttempts(node *yaml.Node, attempts int) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: fmt.Sprintf("invalid retry attempts: %d", attempts),
+	}
+}
+
+// FileNotFound returns ErrFileNotFound for a given file path
+func FileNotFound(path string, node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: fmt.Sprintf("file not found: %q", path),
+	}
+}

--- a/plugin/exec/defaults.go
+++ b/plugin/exec/defaults.go
@@ -5,9 +5,8 @@
 package exec
 
 import (
+	"github.com/gdt-dev/core/parse"
 	"gopkg.in/yaml.v3"
-
-	"github.com/gdt-dev/core/api"
 )
 
 type execDefaults struct{}
@@ -19,21 +18,21 @@ type Defaults struct {
 
 func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
 		case "exec":
 			if valNode.Kind != yaml.MappingNode {
-				return api.ExpectedMapAt(valNode)
+				return parse.ExpectedMapAt(valNode)
 			}
 			ed := execDefaults{}
 			if err := valNode.Decode(&ed); err != nil {

--- a/plugin/exec/errors.go
+++ b/plugin/exec/errors.go
@@ -7,40 +7,8 @@ package exec
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/gdt-dev/core/api"
 )
-
-// ExecEmpty returns an ErrExecEmpty with the line/column of the supplied YAML
-// node.
-func ExecEmpty(node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: "expected non-empty exec field",
-	}
-}
-
-// ExecInvalidShellParse returns an ErrExecInvalid with the error from
-// shlex.Split
-func ExecInvalidShellParse(err error, node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("cannot parse shell args: %s", err),
-	}
-}
-
-// ExecUnknownShell returns a wrapped version of ParseError that indicates the
-// user specified an unknown shell.
-func ExecUnknownShell(shell string, node *yaml.Node) error {
-	return &api.ParseError{
-		Line:    node.Line,
-		Column:  node.Column,
-		Message: fmt.Sprintf("unknown shell %q", shell),
-	}
-}
 
 // ExecRuntimeError returns a RuntimeError with an error from the Exec() call.
 func ExecRuntimeError(err error) error {

--- a/plugin/exec/parse_test.go
+++ b/plugin/exec/parse_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/parse"
 	gdtexec "github.com/gdt-dev/core/plugin/exec"
 	"github.com/gdt-dev/core/scenario"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func TestParseUnknownShell(t *testing.T) {
 		scenario.WithPath(fp),
 	)
 	assert.NotNil(err)
-	assert.ErrorIs(err, api.ErrParse)
+	assert.Error(err, &parse.Error{})
 	assert.Nil(s)
 }
 

--- a/scenario/defaults.go
+++ b/scenario/defaults.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/parse"
 )
 
 const (
@@ -32,14 +33,14 @@ type Defaults struct {
 
 func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
-		return api.ExpectedMapAt(node)
+		return parse.ExpectedMapAt(node)
 	}
 	// maps/structs are stored in a top-level Node.Content field which is a
 	// concatenated slice of Node pointers in pairs of key/values.
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		if keyNode.Kind != yaml.ScalarNode {
-			return api.ExpectedScalarAt(keyNode)
+			return parse.ExpectedScalarAt(keyNode)
 		}
 		key := keyNode.Value
 		valNode := node.Content[i+1]
@@ -50,7 +51,7 @@ func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 			case yaml.MappingNode:
 				// We support the old-style timeout:after
 				if err := valNode.Decode(&to); err != nil {
-					return api.ExpectedTimeoutAt(valNode)
+					return parse.ExpectedTimeoutAt(valNode)
 				}
 			case yaml.ScalarNode:
 				// We also support a straight string duration
@@ -58,7 +59,7 @@ func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 					After: valNode.Value,
 				}
 			default:
-				return api.ExpectedScalarOrMapAt(valNode)
+				return parse.ExpectedScalarOrMapAt(valNode)
 			}
 			_, err := time.ParseDuration(to.After)
 			if err != nil {
@@ -67,16 +68,16 @@ func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 			d.Timeout = to
 		case "retry":
 			if valNode.Kind != yaml.MappingNode {
-				return api.ExpectedMapAt(valNode)
+				return parse.ExpectedMapAt(valNode)
 			}
 			var r *api.Retry
 			if err := valNode.Decode(&r); err != nil {
-				return api.ExpectedRetryAt(valNode)
+				return parse.ExpectedRetryAt(valNode)
 			}
 			if r.Attempts != nil {
 				attempts := *r.Attempts
 				if attempts < 1 {
-					return api.InvalidRetryAttempts(valNode, attempts)
+					return parse.InvalidRetryAttempts(valNode, attempts)
 				}
 			}
 			if r.Interval != "" {

--- a/scenario/from.go
+++ b/scenario/from.go
@@ -9,7 +9,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/gdt-dev/core/api"
 	"github.com/gdt-dev/core/parse"
 )
 
@@ -35,7 +34,7 @@ func FromBytes(
 	s := New(mods...)
 	expanded := parse.ExpandWithFixedDoubleDollar(string(contents))
 	if err := yaml.Unmarshal([]byte(expanded), s); err != nil {
-		if ep, ok := err.(*api.ParseError); ok {
+		if ep, ok := err.(*parse.Error); ok {
 			ep.Path = s.Path
 			ep.SetContents()
 			return nil, ep

--- a/scenario/parse_test.go
+++ b/scenario/parse_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/parse"
 	"github.com/gdt-dev/core/scenario"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,7 +120,7 @@ func TestBadTimeout(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.ErrorIs(err, api.ErrParse)
+	assert.Error(err, &parse.Error{})
 	assert.Nil(s)
 }
 
@@ -158,7 +159,7 @@ func TestBadRetry(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.ErrorIs(err, api.ErrParse)
+	assert.Error(err, &parse.Error{})
 	assert.Nil(s)
 }
 
@@ -171,7 +172,7 @@ func TestBadRetryAttempts(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.ErrorIs(err, api.ErrParse)
+	assert.Error(err, &parse.Error{})
 	assert.Nil(s)
 }
 
@@ -197,8 +198,8 @@ func TestKnownSpec(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("foo", s.Name)
@@ -265,8 +266,8 @@ func TestMultipleSpec(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("foo-bar", s.Name)
@@ -305,8 +306,8 @@ func TestEnvExpansion(t *testing.T) {
 	t.Setenv("DESCRIPTION", "Bazzy Bizzy")
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("env-expansion", s.Name)
@@ -373,8 +374,8 @@ func TestScenarioDefaults(t *testing.T) {
 	require.Nil(err)
 
 	s, err := scenario.FromReader(f, scenario.WithPath(fp))
-	assert.Nil(err)
-	assert.NotNil(s)
+	require.Nil(err)
+	require.NotNil(s)
 
 	assert.IsType(&scenario.Scenario{}, s)
 	assert.Equal("foo-timeout", s.Name)


### PR DESCRIPTION
consolidates the parse error handling and definitions into the `parse/` package, which does not import the `api/` package.