### PR TITLE
execute gdt tests outside of go test tool

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -112,6 +112,7 @@ func UnknownSourceType(source interface{}) error {
 var (
 	// RuntimeError is the base error class for all errors occurring during
 	// runtime (and not during the parsing of a scenario or spec)
+	// nolint:staticcheck
 	RuntimeError = errors.New("runtime error")
 	// ErrRequiredFixture is returned when a required fixture has not
 	// been registered with the context.

--- a/api/runnable.go
+++ b/api/runnable.go
@@ -6,15 +6,15 @@ package api
 
 import (
 	"context"
-	"testing"
 )
 
-// Runnable are things that Run a `*testing.T`
+// Runnable are things that Run either a `*testing.T` or a `*run.Options` that
+// tracks execution of test units being run.
 type Runnable interface {
-	// Run accepts a context and a `*testing.T` and runs some tests within that
-	// context
+	// Run accepts a context and either a `*testing.T` or a `*run.Options` and
+	// runs some tests within that context.
 	//
 	// Errors returned by Run() are **RuntimeErrors**, not failures in
 	// assertions.
-	Run(context.Context, *testing.T) error
+	Run(context.Context, any) error
 }

--- a/api/t.go
+++ b/api/t.go
@@ -1,0 +1,26 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package api
+
+// T is the shared interface surface area between an "internal" runnable test
+// case when the `go test` tool is used as the test runner and an "external"
+// runnable test case when the `gdt` CLI tool is used as the test runner. It's
+// essentially a subset of Go's `testing.TB` interface methods.
+type T interface {
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Name() string
+	Skip(args ...any)
+	SkipNow()
+	Skipf(format string, args ...any)
+	Skipped() bool
+}

--- a/context/context.go
+++ b/context/context.go
@@ -12,16 +12,19 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/testunit"
 )
 
 type ContextKey string
 
 var (
-	debugKey    = ContextKey("gdt.debug")
-	traceKey    = ContextKey("gdt.trace")
-	pluginsKey  = ContextKey("gdt.plugins")
-	fixturesKey = ContextKey("gdt.fixtures")
-	runKey      = ContextKey("gdt.run")
+	debugPrefixKey = ContextKey("gdt.debug.prefix")
+	debugKey       = ContextKey("gdt.debug")
+	traceKey       = ContextKey("gdt.trace")
+	pluginsKey     = ContextKey("gdt.plugins")
+	fixturesKey    = ContextKey("gdt.fixtures")
+	runKey         = ContextKey("gdt.run")
+	unitKey        = ContextKey("gdt.unit")
 )
 
 // ContextModifier sets some value on the context
@@ -88,6 +91,12 @@ func WithDebug(writers ...io.Writer) ContextModifier {
 	}
 }
 
+func WithDebugPrefix(prefix string) ContextModifier {
+	return func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, debugPrefixKey, prefix)
+	}
+}
+
 // WithPlugins sets a context's Plugins
 func WithPlugins(plugins []api.Plugin) ContextModifier {
 	return func(ctx context.Context) context.Context {
@@ -116,6 +125,14 @@ func SetDebug(
 		writers = []io.Writer{os.Stdout}
 	}
 	return context.WithValue(ctx, debugKey, writers)
+}
+
+// SetDebugPrefix sets the prefix on the gdt debug log entries.
+func SetDebugPrefix(
+	ctx context.Context,
+	prefix string,
+) context.Context {
+	return context.WithValue(ctx, debugPrefixKey, prefix)
 }
 
 // RegisterFixture registers a named fixtures with the context
@@ -186,6 +203,15 @@ func PopTrace(
 	stack := TraceStack(ctx)
 	stack = stack[:len(stack)-1]
 	return context.WithValue(ctx, traceKey, stack)
+}
+
+// SetTestUnit sets the current test unit in the context. Any previously existing
+// test unit in the context is overwritten.
+func SetTestUnit(
+	ctx context.Context,
+	tu *testunit.TestUnit,
+) context.Context {
+	return context.WithValue(ctx, unitKey, tu)
 }
 
 // New returns a new Context

--- a/context/getter.go
+++ b/context/getter.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 
 	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/testunit"
 )
 
 const (
-	traceDelimiter = "/"
+	defaultDebugPrefix = "[gdt]"
+	traceDelimiter     = "/"
 )
 
 // Trace gets a context's trace name stack joined together with
@@ -49,6 +51,18 @@ func Debug(ctx context.Context) []io.Writer {
 		return v.([]io.Writer)
 	}
 	return []io.Writer{}
+}
+
+// DebugPrefix gets a context's debug prefix or the default prefix if none is
+// set.
+func DebugPrefix(ctx context.Context) string {
+	if ctx == nil {
+		return defaultDebugPrefix
+	}
+	if v := ctx.Value(debugPrefixKey); v != nil {
+		return v.(string)
+	}
+	return defaultDebugPrefix
 }
 
 // Plugins gets a context's Plugins
@@ -87,6 +101,17 @@ func Run(ctx context.Context) map[string]any {
 // deprecated: use Run()
 func PriorRun(ctx context.Context) map[string]any {
 	return Run(ctx)
+}
+
+// TestUnit gets a context's test unit
+func TestUnit(ctx context.Context) *testunit.TestUnit {
+	if ctx == nil {
+		return nil
+	}
+	if v := ctx.Value(unitKey); v != nil {
+		return v.(*testunit.TestUnit)
+	}
+	return nil
 }
 
 // ReplaceVariables replaces all occurrences of any of the variables in the

--- a/debug/print.go
+++ b/debug/print.go
@@ -13,52 +13,62 @@ import (
 )
 
 // Printf writes a message with optional message arguments to the context's
-// Debug output.
+// Debug output. The behaviour is analogous to `fmt.Printf`.
 func Printf(
 	ctx context.Context,
 	format string,
-	args ...interface{},
+	args ...any,
 ) {
+	tu := gdtcontext.TestUnit(ctx)
 	writers := gdtcontext.Debug(ctx)
-	if len(writers) == 0 {
+	if len(writers) == 0 && tu == nil {
 		return
 	}
 
 	trace := gdtcontext.Trace(ctx)
 
-	if !strings.HasPrefix(format, "[gdt] ") {
-		format = "[gdt] [" + trace + "] " + format
+	prefix := gdtcontext.DebugPrefix(ctx)
+	msg := prefix
+	if trace != "" {
+		msg += " [" + trace + "] "
 	}
-	msg := fmt.Sprintf(format, args...)
+	msg += fmt.Sprintf(format, args...)
+	msg = strings.TrimSuffix(msg, "\n") + "\n"
 	for _, w := range writers {
 		//nolint:errcheck
 		w.Write([]byte(msg))
+	}
+	if tu != nil {
+		tu.Log(strings.TrimSuffix(msg, "\n"))
 	}
 }
 
 // Println writes a message with optional message arguments to the context's
-// Debug output, ensuring there is a newline in the message line.
+// Debug output, ensuring there is a newline in the message line. This is
+// analogous to `fmt.Println` behaviour.
 func Println(
 	ctx context.Context,
-	format string,
-	args ...interface{},
+	args ...any,
 ) {
+	tu := gdtcontext.TestUnit(ctx)
 	writers := gdtcontext.Debug(ctx)
-	if len(writers) == 0 {
+	if len(writers) == 0 && tu == nil {
 		return
 	}
 
 	trace := gdtcontext.Trace(ctx)
 
-	if !strings.HasPrefix(format, "[gdt] ") {
-		format = "[gdt] [" + trace + "] " + format
+	prefix := gdtcontext.DebugPrefix(ctx)
+	msg := prefix
+	if trace != "" {
+		msg += " [" + trace + "] "
 	}
-	if !strings.HasSuffix(format, "\n") {
-		format += "\n"
-	}
-	msg := fmt.Sprintf(format, args...)
+	msg += fmt.Sprintln(args...)
 	for _, w := range writers {
 		//nolint:errcheck
 		w.Write([]byte(msg))
+	}
+	if tu != nil {
+		tu.Log(strings.TrimSuffix(msg, "\n"))
 	}
 }

--- a/internal/testutil/fixture/errstarter/fixture.go
+++ b/internal/testutil/fixture/errstarter/fixture.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	errStarter = func(_ context.Context) error {
+		// nolint:staticcheck
 		return fmt.Errorf("error starting fixture!")
 	}
 

--- a/internal/testutil/plugin/failer/plugin.go
+++ b/internal/testutil/plugin/failer/plugin.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/gdt-dev/core/api"
-	gdtapi "github.com/gdt-dev/core/api"
 	"github.com/gdt-dev/core/parse"
 	"github.com/gdt-dev/core/plugin"
 	"github.com/samber/lo"
@@ -85,7 +84,8 @@ func (s *Spec) Timeout() *api.Timeout {
 }
 
 func (s *Spec) Eval(context.Context) (*api.Result, error) {
-	return nil, fmt.Errorf("%w: Indy, bad dates!", gdtapi.RuntimeError)
+	// nolint:staticcheck
+	return nil, fmt.Errorf("%w: Indy, bad dates!", api.RuntimeError)
 }
 
 func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
@@ -108,6 +108,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 			}
 			s.Fail, _ = strconv.ParseBool(valNode.Value)
 			if s.Fail {
+				// nolint:staticcheck
 				return fmt.Errorf("Indy, bad parse!")
 			}
 		default:

--- a/internal/testutil/plugin/foo/plugin.go
+++ b/internal/testutil/plugin/foo/plugin.go
@@ -115,7 +115,7 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 
 func (s *Spec) Eval(ctx context.Context) (*api.Result, error) {
 	fails := []error{}
-	debug.Println(ctx, "in %s Foo=%s", s.Title(), s.Foo)
+	debug.Printf(ctx, "in %s Foo=%s", s.Title(), s.Foo)
 	// This is just a silly test to demonstrate how to write Eval() methods
 	// for plugin Spec specialization classes.
 	if s.Name == "bar" && s.Foo != "bar" {

--- a/parse/expand.go
+++ b/parse/expand.go
@@ -23,5 +23,5 @@ const (
 func ExpandWithFixedDoubleDollar(subject string) string {
 	os.Setenv(dollarSignReplacementToken, "$")
 	replaceStr := fmt.Sprintf("${%s}", dollarSignReplacementToken)
-	return os.ExpandEnv(strings.Replace(subject, "$$", replaceStr, -1))
+	return os.ExpandEnv(strings.ReplaceAll(subject, "$$", replaceStr))
 }

--- a/plugin/exec/action.go
+++ b/plugin/exec/action.go
@@ -67,7 +67,7 @@ func (a *Action) Do(
 		return gdtcontext.ReplaceVariables(ctx, arg)
 	})
 
-	debug.Println(ctx, "exec: %s %s", target, args)
+	debug.Printf(ctx, "exec: %s %s", target, args)
 
 	cmd := exec.CommandContext(ctx, target, args...)
 
@@ -89,10 +89,10 @@ func (a *Action) Do(
 	}
 	if outbuf != nil {
 		if _, err = outbuf.ReadFrom(outpipe); err != nil {
-			debug.Println(ctx, "exec: error reading from stdout: %s", err)
+			debug.Printf(ctx, "exec: error reading from stdout: %s", err)
 		}
 		if outbuf.Len() > 0 {
-			debug.Println(
+			debug.Printf(
 				ctx, "exec: stdout: %s",
 				strings.TrimSpace(outbuf.String()),
 			)
@@ -100,10 +100,10 @@ func (a *Action) Do(
 	}
 	if errbuf != nil {
 		if _, err = errbuf.ReadFrom(errpipe); err != nil {
-			debug.Println(ctx, "exec: error reading from stderr: %s", err)
+			debug.Printf(ctx, "exec: error reading from stderr: %s", err)
 		}
 		if errbuf.Len() > 0 {
-			debug.Println(
+			debug.Printf(
 				ctx, "exec: stderr: %s",
 				strings.TrimSpace(errbuf.String()),
 			)

--- a/run/new.go
+++ b/run/new.go
@@ -1,0 +1,18 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package run
+
+type Option func(*Run)
+
+// New returns a new Run object that stores test run state.
+func New(opts ...Option) *Run {
+	r := &Run{
+		scenarioResults: map[string][]TestUnitResult{},
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}

--- a/run/run.go
+++ b/run/run.go
@@ -1,0 +1,111 @@
+package run
+
+import (
+	"slices"
+	"time"
+
+	"github.com/gdt-dev/core/api"
+	"github.com/gdt-dev/core/testunit"
+	"github.com/samber/lo"
+)
+
+// Run stores state of a test run when tests are executed with the `gdt` CLI
+// tool.
+type Run struct {
+	// scenarioResults is a map, keyed by the Scenario path, of slices of
+	// TestUnitResult structs corresponding to the test specs in the scenario.
+	// There is guaranteed to be exactly the same number of TestUnitResults in
+	// the slice as scenarios in the scenario.
+	scenarioResults map[string][]TestUnitResult
+}
+
+// OK returns true if all Scenarios in the Run had all successful test units.
+func (r *Run) OK() bool {
+	return !lo.SomeBy(lo.Values(r.scenarioResults), func(results []TestUnitResult) bool {
+		return !lo.SomeBy(results, func(r TestUnitResult) bool {
+			return len(r.failures) == 0
+		})
+	})
+}
+
+// ScenarioPaths returns a sorted list of Scenario Paths.
+func (r *Run) ScenarioPaths() []string {
+	paths := lo.Keys(r.scenarioResults)
+	slices.Sort(paths)
+	return paths
+}
+
+// ScenarioResults returns the set of TestUnitResults for a Scenario with the
+// supplied path.
+func (r *Run) ScenarioResults(path string) []TestUnitResult {
+	return r.scenarioResults[path]
+}
+
+// StoreResult stores a test unit result to the Run for the supplied test unit.
+func (r *Run) StoreResult(
+	index int,
+	path string, // the Scenario.Path
+	tu *testunit.TestUnit,
+	res *api.Result,
+) {
+	if _, ok := r.scenarioResults[path]; !ok {
+		r.scenarioResults[path] = []TestUnitResult{}
+	}
+	r.scenarioResults[path] = append(
+		r.scenarioResults[path],
+		TestUnitResult{
+			index:    index,
+			name:     tu.Name(),
+			elapsed:  tu.Elapsed(),
+			skipped:  tu.Skipped(),
+			failures: res.Failures(),
+			detail:   tu.Detail(),
+		},
+	)
+}
+
+// TestUnitResult stores a summary of the test execution of a single test unit.
+type TestUnitResult struct {
+	// index is the 0-based index of the test unit within the test scenario.
+	index int
+	// name is the short name of the test unit
+	name string
+	// skipped is true if the test unit was skipped
+	skipped bool
+	// failures is the collection of assertion failures for the test spec that
+	// occurred during the run. this will NOT include RuntimeErrors.
+	failures []error
+	// elapsed is the time take to execute the test unit
+	elapsed time.Duration
+	// detail is a buffer holding any log entries made during the run of the
+	// test spec.
+	detail string
+}
+
+func (u TestUnitResult) OK() bool {
+	return len(u.failures) == 0
+}
+
+func (u TestUnitResult) Name() string {
+	return u.name
+}
+
+func (u TestUnitResult) Index() int {
+	return u.index
+}
+
+func (u TestUnitResult) Failures() []error {
+	return u.failures
+}
+
+func (u TestUnitResult) Skipped() bool {
+	return u.skipped
+}
+
+func (u TestUnitResult) Detail() string {
+	return u.detail
+}
+
+func (u TestUnitResult) Elapsed() time.Duration {
+	return u.elapsed
+}

--- a/suite/run.go
+++ b/suite/run.go
@@ -6,13 +6,12 @@ package suite
 
 import (
 	"context"
-	"testing"
 )
 
-// Run executes the tests in the test case
-func (s *Suite) Run(ctx context.Context, t *testing.T) error {
+// Run executes the tests in the test suite
+func (s *Suite) Run(ctx context.Context, subject any) error {
 	for _, sc := range s.Scenarios {
-		if err := sc.Run(ctx, t); err != nil {
+		if err := sc.Run(ctx, subject); err != nil {
 			return err
 		}
 	}

--- a/testunit/new.go
+++ b/testunit/new.go
@@ -1,0 +1,55 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package testunit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	nameSeparator = "/"
+)
+
+type Option func(*TestUnit)
+
+// WithParent creates TestUnit pointing at a parent test unit.
+func WithParent(parent *TestUnit) Option {
+	return func(u *TestUnit) {
+		u.parent = parent
+		if u.name != "" {
+			u.name = fmt.Sprintf("%s%s%s", parent.name, nameSeparator, u.name)
+		} else {
+			u.name = u.parent.name
+		}
+	}
+}
+
+// WithName creates TestUnit with a specified test unit name.
+func WithName(name string) Option {
+	return func(u *TestUnit) {
+		if u.parent != nil {
+			u.name = fmt.Sprintf("%s%s%s", u.parent.name, nameSeparator, name)
+		} else {
+			u.name = name
+		}
+	}
+}
+
+// New returns a new initialized *TestUnit
+func New(ctx context.Context, opts ...Option) *TestUnit {
+	u := &TestUnit{
+		detail:   &strings.Builder{},
+		failures: []error{},
+	}
+	for _, opt := range opts {
+		opt(u)
+	}
+	u.ctx, u.cancelCtx = context.WithCancel(ctx)
+	u.started = time.Now()
+	return u
+}

--- a/testunit/testunit.go
+++ b/testunit/testunit.go
@@ -1,0 +1,192 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package testunit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+const (
+	indent = "   "
+)
+
+// TestUnit contains state about a unit under test. This class is used by the
+// `gdt` CLI tool instead of the `*testing.T` struct which is used when a `gdt`
+// test case is executed by the `go test` tool. An `*api.Spec` is converted
+// into a TestUnit by the `Scenario.Run()` method. TestUnit implements `api.T`.
+type TestUnit struct {
+	sync.RWMutex
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+	// detail is our log stream the test unit can write results/messages to.
+	detail *strings.Builder
+	// name is the name/title of the test unit
+	name string
+	// parent points at another test unit if it's a subtest.
+	parent *TestUnit
+	// failed is true if the test unit has been marked as failed.
+	failed bool
+	// failures is a collection of assertion failures encountered for the test
+	// unit.
+	failures []error
+	// skipped is true if the test unit has been marked as skipped.
+	skipped bool
+	// done is true if the test unit is finished and any subtests have
+	// completed.
+	done bool
+	// start is the timestamp of when the test unit was started.
+	started time.Time
+	// elapsed is the amount of time spent executing the test unit.
+	elapsed time.Duration
+}
+
+func (u *TestUnit) finish() {
+	u.Lock()
+	u.elapsed += time.Since(u.started)
+	u.done = true
+	u.Unlock()
+}
+
+// Name returns the full name of the test unit. The test unit name is a
+// concatenation of the parent(s) name and this test unit's name.
+func (u *TestUnit) Name() string {
+	return u.name
+}
+
+// Elapsed returns the duration the test took to execute.
+func (u *TestUnit) Elapsed() time.Duration {
+	return u.elapsed
+}
+
+// Detail returns the saved log entries.
+func (u *TestUnit) Detail() string {
+	if u.detail != nil {
+		return u.detail.String()
+	}
+	return ""
+}
+
+// Fail marks the function as having failed but continues execution.
+func (u *TestUnit) Fail() {
+	if u.parent != nil {
+		u.parent.Fail()
+	}
+	u.Lock()
+	defer u.Unlock()
+	// u.done needs to be locked to synchronize checks to u.done in parent tests.
+	if u.done {
+		panic("Fail called after " + u.name + " has completed")
+	}
+	u.failed = true
+}
+
+// Failed reports whether the test unit has failed.
+func (u *TestUnit) Failed() bool {
+	u.RLock()
+	defer u.RUnlock()
+
+	return u.failed
+}
+
+// FailNow marks the function as having failed and stops its execution
+// Execution will continue at the next test unit.
+func (u *TestUnit) FailNow() {
+	u.Fail()
+	u.finish()
+}
+
+func (u *TestUnit) log(s string) {
+	if u.detail == nil {
+		return
+	}
+	s = strings.TrimSuffix(s, "\n")
+	// Second and subsequent lines are indented 4 spaces. This is in addition to
+	// the indentation provided by outputWriter.
+	s = strings.ReplaceAll(s, "\n", "\n"+indent)
+	s += "\n"
+	u.detail.WriteString(s)
+}
+
+// Log writes an entry to the detail log, ensuring a newline at the end of the
+// log line.
+func (u *TestUnit) Log(args ...any) {
+	u.log(fmt.Sprintln(args...))
+}
+
+// Logf writes an entry to the detail log.
+func (u *TestUnit) Logf(format string, args ...any) {
+	u.log(fmt.Sprintf(format, args...))
+}
+
+// Error adds the supplied errors or error message strings to the test unit's
+// collected assertion failures. Execution will continue after marking the test
+// unit as failed.
+func (u *TestUnit) Error(args ...any) {
+	errs := lo.Map(args, func(arg any, _ int) error {
+		switch arg := arg.(type) {
+		case error:
+			return arg
+		default:
+			return fmt.Errorf("%s", arg)
+		}
+	})
+	u.failures = append(u.failures, errs...)
+	u.Fail()
+}
+
+// Errorf adds an error to the test unit's collected assertion failures.
+// Execution will continue after marking the test unit as failed.
+func (u *TestUnit) Errorf(format string, args ...any) {
+	u.failures = append(u.failures, fmt.Errorf(format, args...))
+	u.Fail()
+}
+
+// Fatal adds the supplied errors or error message strings to the test unit's
+// collected assertion failures and immediately stops execution of the test
+// unit.
+func (u *TestUnit) Fatal(args ...any) {
+	u.Error(args...)
+	u.FailNow()
+}
+
+// Fatalf adds an error to the to the test unit's collected assertion failures
+// and immediately stops execution of the test unit.
+func (u *TestUnit) Fatalf(format string, args ...any) {
+	u.Errorf(format, args...)
+	u.FailNow()
+}
+
+// Skip is equivalent to Log followed by SkipNow.
+func (u *TestUnit) Skip(args ...any) {
+	u.Log(args...)
+	u.SkipNow()
+}
+
+// Skipf is equivalent to Logf followed by SkipNow.
+func (u *TestUnit) Skipf(format string, args ...any) {
+	u.Logf(format, args...)
+	u.SkipNow()
+}
+
+// SkipNow marks the test unit as having been skipped and stops its execution.
+func (u *TestUnit) SkipNow() {
+	u.Lock()
+	defer u.RUnlock()
+	u.skipped = true
+	u.finish()
+}
+
+// Skipped reports whether the test was skipped.
+func (u *TestUnit) Skipped() bool {
+	u.RLock()
+	defer u.RUnlock()
+	return u.skipped
+}


### PR DESCRIPTION
Adds functionality to the core library to allow gdt test scenarios to be executed by a test runner other than the `go test` tool.

An upcoming patch to `gdt-dev/gdt` adds a `gdt run` command that uses this functionality:

```
jaypipes@megabox:pts/3->/home/jaypipes/src/github.com/gdt-dev/gdt (0) git:(cli)
> ./bin/gdt run -v ../core/plugin/exec/testdata/echo-cat.yaml
=== RUN: ../core/plugin/exec/testdata/echo-cat.yaml
--- PASS: echo-cat/0 (0s)
─────────────────────────────────────────────────────────────────────────────────────
                                 DETAIL
─────────────────────────────────────────────────────────────────────────────────────
[gdt] [echo-cat/0] using timeout of 10s [plugin default]
[gdt] [echo-cat/0] exec: echo [cat]
[gdt] [echo-cat/0] exec: stdout: cat
[gdt] [echo-cat/0] spec/run: single-shot (no retries) ok: true
─────────────────────────────────────────────────────────────────────────────────────
--- PASS: echo-cat/1 (0s)
─────────────────────────────────────────────────────────────────────────────────────
                                 DETAIL
─────────────────────────────────────────────────────────────────────────────────────
[gdt] [echo-cat/1] using timeout of 10s [plugin default]
[gdt] [echo-cat/1] exec: sh [-c echo cat 1>&2]
[gdt] [echo-cat/1] exec: stderr: cat
[gdt] [echo-cat/1] spec/run: single-shot (no retries) ok: true
─────────────────────────────────────────────────────────────────────────────────────
PASS (0s)
PASS
```

Issue gdt-dev/gdt#55