### PR TITLE
add Scenario `depends` field

### DIFF
--- a/api/dependency.go
+++ b/api/dependency.go
@@ -1,0 +1,23 @@
+package api
+
+// Dependency describes a prerequisite binary or package that must be present.
+type Dependency struct {
+	// Name is the name of the binary or package
+	Name string `yaml:"name"`
+	// When describes any constraining conditions that apply to this
+	// Dependency.
+	When *DependencyConstraints `yaml:"when,omitempty"`
+}
+
+// DependencyConstraints describes constraining conditions that apply to a
+// Dependency, for instance whether the dependency is only required on a
+// particular OS or whether a particular version constraint applies to the
+// dependency.
+type DependencyConstraints struct {
+	// OS indicates that the dependency only applies when the tests are run on
+	// a particular operating system.
+	OS string `yaml:"os,omitempty"`
+	// Version indicates a version constraint to apply to the dependency, e.g.
+	// >= 1.2.3
+	Version string `yaml:"version,omitempty"`
+}

--- a/api/error.go
+++ b/api/error.go
@@ -7,6 +7,7 @@ package api
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -120,6 +121,12 @@ var (
 		"%w: required fixture missing",
 		RuntimeError,
 	)
+	// ErrDependencyNotSatisfied is returned when a required fixture has not
+	// been registered with the context.
+	ErrDependencyNotSatisfied = fmt.Errorf(
+		"%w: dependency not satisfied",
+		RuntimeError,
+	)
 	// ErrTimeoutConflict is returned when the Go test tool's timeout conflicts
 	// with either a total wait time or a timeout in a scenario or test spec
 	ErrTimeoutConflict = fmt.Errorf(
@@ -127,6 +134,24 @@ var (
 		RuntimeError,
 	)
 )
+
+// DependencyNotSatified returns an ErrDependencyNotSatisfied with the supplied
+// dependency name and optional constraints.
+func DependencyNotSatisfied(dep *Dependency) error {
+	constraintsStr := ""
+	constraints := []string{}
+	progName := dep.Name
+	if dep.When != nil {
+		if dep.When.OS != "" {
+			constraints = append(constraints, "OS:"+dep.When.OS)
+		}
+		if dep.When.Version != "" {
+			constraints = append(constraints, "VERSION:"+dep.When.Version)
+		}
+		constraintsStr = fmt.Sprintf(" (%s)", strings.Join(constraints, ","))
+	}
+	return fmt.Errorf("%w: %s%s", ErrDependencyNotSatisfied, progName, constraintsStr)
+}
 
 // RequiredFixtureMissing returns an ErrRequiredFixture with the supplied
 // fixture name

--- a/scenario/depends.go
+++ b/scenario/depends.go
@@ -1,0 +1,75 @@
+package scenario
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/gdt-dev/core/api"
+	gdtcontext "github.com/gdt-dev/core/context"
+	"github.com/gdt-dev/core/debug"
+)
+
+// checkDependencies examines the scenario's set of dependencies and returns a
+// runtime error if any dependency isn't satisfied.
+func (s *Scenario) checkDependencies(
+	ctx context.Context,
+) error {
+	if len(s.Depends) == 0 {
+		return nil
+	}
+	ctx = gdtcontext.PushTrace(ctx, "scenario.check-deps")
+	defer func() {
+		ctx = gdtcontext.PopTrace(ctx)
+	}()
+
+	for _, dep := range s.Depends {
+		if err := s.checkDependency(ctx, dep); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkDependency returns an error if the supplied Dependency isn't satisfied.
+func (s *Scenario) checkDependency(
+	ctx context.Context,
+	dep *api.Dependency,
+) error {
+	if dep == nil {
+		return nil
+	}
+
+	when := dep.When
+	if when != nil {
+		if when.OS != "" {
+			if !strings.EqualFold(runtime.GOOS, when.OS) {
+				return nil
+			}
+		}
+	}
+
+	_, err := exec.LookPath(dep.Name)
+	if err != nil {
+		execErr, ok := err.(*exec.Error)
+		if ok && execErr.Err == exec.ErrNotFound {
+			return api.DependencyNotSatisfied(dep)
+		} else {
+			return fmt.Errorf(
+				"error checking for program %q: %w",
+				dep.Name, err,
+			)
+		}
+	}
+
+	if when != nil && when.Version != "" {
+		// TODO(jaypipes): do some robust version checking for
+		// applications/packages here.
+		_ = when.Version
+	}
+
+	debug.Printf(ctx, "dependency %q satisfied", dep.Name)
+	return nil
+}

--- a/scenario/parse.go
+++ b/scenario/parse.go
@@ -48,6 +48,15 @@ func (s *Scenario) UnmarshalYAML(node *yaml.Node) error {
 				return parse.ExpectedScalarAt(valNode)
 			}
 			s.Description = valNode.Value
+		case "depends", "depends-on":
+			if valNode.Kind != yaml.SequenceNode {
+				return parse.ExpectedSequenceAt(valNode)
+			}
+			var deps []*api.Dependency
+			if err := valNode.Decode(&deps); err != nil {
+				return parse.ExpectedSequenceAt(valNode)
+			}
+			s.Depends = deps
 		case "fixtures":
 			if valNode.Kind != yaml.SequenceNode {
 				return parse.ExpectedSequenceAt(valNode)

--- a/scenario/run.go
+++ b/scenario/run.go
@@ -43,6 +43,9 @@ func (s *Scenario) Run(ctx context.Context, subject any) error {
 			_ = os.Chdir(cwd)
 		}()
 	}
+	if err := s.checkDependencies(ctx); err != nil {
+		return err
+	}
 	switch subject := subject.(type) {
 	case *testing.T:
 		return s.runGo(ctx, subject)

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -15,6 +15,9 @@ import (
 type Scenario struct {
 	// Timings is the collection of max wait/timeout values for the scenario.
 	Timings *api.Timings `yaml:"-"`
+	// Depends contains all prerequisite dependencies required to execute the
+	// test scenario.
+	Depends []*api.Dependency `yaml:"depends,omitempty"`
 	// Path is the filepath to the test scenario YAML file.
 	Path string `yaml:"-"`
 	// Name is the short name for the test case. If empty, defaults to the base

--- a/scenario/testdata/depends-not-satisfied-os.yaml
+++ b/scenario/testdata/depends-not-satisfied-os.yaml
@@ -1,0 +1,9 @@
+name: depends-not-satisfied-os
+description: a scenario with unsatisfiable OS-specific dependencies
+depends:
+  - name: nonexistingbinary
+    when:
+      os: windows
+tests:
+  - name: should-not-get-here-on-windows
+    foo: baz

--- a/scenario/testdata/missing-depends.yaml
+++ b/scenario/testdata/missing-depends.yaml
@@ -1,0 +1,7 @@
+name: missing-depends
+description: a scenario with unsatisfiable dependencies
+depends:
+  - name: nonexistingbinary
+tests:
+  - name: should-not-get-here
+    foo: bar


### PR DESCRIPTION
Allows specifying binaries that should be available/executable for a test scenario to be run. Before running the test scenario, we check to see whether the dependencies are available in the host path and if not, return a RuntimeError.

Issue gdt-dev/gdt#60