### PR TITLE
ensure elapsed time is stored to testunit

### DIFF
--- a/scenario/run.go
+++ b/scenario/run.go
@@ -136,6 +136,8 @@ func (s *Scenario) runExternal(ctx context.Context, run *run.Run) error {
 		}
 		if len(res.Failures()) > 0 {
 			tu.FailNow()
+		} else {
+			tu.Finish() // necessary for elapsed timer to stop
 		}
 		scenOK = scenOK && !tu.Failed()
 

--- a/testunit/testunit.go
+++ b/testunit/testunit.go
@@ -48,7 +48,7 @@ type TestUnit struct {
 	elapsed time.Duration
 }
 
-func (u *TestUnit) finish() {
+func (u *TestUnit) Finish() {
 	u.Lock()
 	u.elapsed += time.Since(u.started)
 	u.done = true
@@ -100,7 +100,7 @@ func (u *TestUnit) Failed() bool {
 // Execution will continue at the next test unit.
 func (u *TestUnit) FailNow() {
 	u.Fail()
-	u.finish()
+	u.Finish()
 }
 
 func (u *TestUnit) log(s string) {
@@ -181,7 +181,7 @@ func (u *TestUnit) SkipNow() {
 	u.Lock()
 	defer u.RUnlock()
 	u.skipped = true
-	u.finish()
+	u.Finish()
 }
 
 // Skipped reports whether the test was skipped.


### PR DESCRIPTION
When executing outside the context of Go testing tool, we were not marking a test unit finished upon successful completion of the test spec, resulting in elapsed times of 0 when run with the gdt CLI tool. This fixes that by ensuring we set the elapsed time by calling Finish() on the test unit.