### PR TITLE
support stop-on-assertion-failure behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ test spec also contains these fields:
   the name of the environment variable to read into the named variable.
 * `assert`: (optional) an object describing the conditions that will be
   asserted about the test action.
+* `assert.require`: (optional) a boolean indicating whether a failed assertion
+  will cause the test scenario's execution to stop. The default behaviour of
+  `gdt` is to continue execution of subsequent test specs in a test scenario when
+  an assertion fails.
 * `assert.exit-code`: (optional) an integer with the expected exit code from the
   executed command. The default successful exit code is 0 and therefore you do
   not need to specify this if you expect a successful exit code.

--- a/api/result.go
+++ b/api/result.go
@@ -16,6 +16,9 @@ package api
 // returned in the Result and the `Scenario.Run` method injects that
 // information into the context that is supplied to the next Spec's `Run`.
 type Result struct {
+	// stopOnFail is an indication to the scenario that if there are any
+	// failures, the scenario should not proceed with test execution.
+	stopOnFail bool
 	// failures is the collection of error messages from assertion failures
 	// that occurred during Eval(). These are *not* `gdterrors.RuntimeError`.
 	failures []error
@@ -37,6 +40,12 @@ func (r *Result) HasData() bool {
 // Data returns the raw run data saved in the result
 func (r *Result) Data() map[string]any {
 	return r.data
+}
+
+// StopOnFail returns true if the test spec indicates that a failure of
+// assertion should stop the execution of the test scenario.
+func (r *Result) StopOnFail() bool {
+	return r.stopOnFail
 }
 
 // Failed returns true if any assertion failed during Eval(), false otherwise.
@@ -92,6 +101,14 @@ type ResultModifier func(*Result)
 func WithData(key string, val any) ResultModifier {
 	return func(r *Result) {
 		r.SetData(key, val)
+	}
+}
+
+// WithStopOnFail sets the stopOnFail value for the test spec result.
+// failures
+func WithStopOnFail(val bool) ResultModifier {
+	return func(r *Result) {
+		r.stopOnFail = val
 	}
 }
 

--- a/parse/error.go
+++ b/parse/error.go
@@ -179,6 +179,16 @@ func ExpectedScalarOrMapAt(node *yaml.Node) error {
 	}
 }
 
+// ExpectedBoolAt returns a parse error indicating a boolean value was expected
+// and annotated with the line/column of the supplied YAML node.
+func ExpectedBoolAt(node *yaml.Node) error {
+	return &Error{
+		Line:    node.Line,
+		Column:  node.Column,
+		Message: "expected boolean value",
+	}
+}
+
 // ExpectedTimeoutAt returns an ErrExpectedTimeout error annotated
 // with the line/column of the supplied YAML node.
 func ExpectedTimeoutAt(node *yaml.Node) error {

--- a/plugin/exec/assertions.go
+++ b/plugin/exec/assertions.go
@@ -18,6 +18,9 @@ import (
 
 // Expect contains the assertions about an Exec Spec's actions
 type Expect struct {
+	// Require indicates that any failed assertion should stop the execution of
+	// the test scenario in which the test spec is contained.
+	Require bool `yaml:"require,omitempty"`
 	// ExitCode is the expected exit code for the executed command. The default
 	// (0) is the universal successful exit code, so you only need to set this
 	// if you expect a non-successful result from executing the command.

--- a/plugin/exec/eval.go
+++ b/plugin/exec/eval.go
@@ -47,5 +47,12 @@ func (s *Spec) Eval(
 			}
 		}
 	}
-	return api.NewResult(api.WithFailures(a.Failures()...)), nil
+	stopOnFail := false
+	if s.Assert != nil {
+		stopOnFail = s.Assert.Require
+	}
+	return api.NewResult(
+		api.WithStopOnFail(stopOnFail),
+		api.WithFailures(a.Failures()...),
+	), nil
 }

--- a/plugin/exec/parse.go
+++ b/plugin/exec/parse.go
@@ -123,6 +123,16 @@ func (s *Spec) UnmarshalYAML(node *yaml.Node) error {
 				return err
 			}
 			s.Assert = e
+		case "require":
+			if valNode.Kind != yaml.MappingNode {
+				return parse.ExpectedMapAt(valNode)
+			}
+			var e *Expect
+			if err := valNode.Decode(&e); err != nil {
+				return err
+			}
+			e.Require = true
+			s.Assert = e
 		case "on":
 			if valNode.Kind != yaml.MappingNode {
 				return parse.ExpectedMapAt(valNode)
@@ -168,6 +178,16 @@ func (e *Expect) UnmarshalYAML(node *yaml.Node) error {
 		key := keyNode.Value
 		valNode := node.Content[i+1]
 		switch key {
+		case "require", "stop-on-fail", "stop_on_fail", "stop.on.fail",
+			"fail-stop", "fail.stop", "fail_stop":
+			if valNode.Kind != yaml.ScalarNode {
+				return parse.ExpectedScalarAt(valNode)
+			}
+			req, err := strconv.ParseBool(valNode.Value)
+			if err != nil {
+				return parse.ExpectedBoolAt(valNode)
+			}
+			e.Require = req
 		case "exit_code", "exit-code":
 			if valNode.Kind != yaml.ScalarNode {
 				return parse.ExpectedScalarAt(valNode)

--- a/plugin/exec/spec.go
+++ b/plugin/exec/spec.go
@@ -13,6 +13,10 @@ import (
 type Spec struct {
 	api.Spec
 	Action
+	// Require is an object containing the conditions that the Spec will
+	// assert. If any condition fails, the test scenario execution will stop
+	// and be marked as failed.
+	Require *Expect `yaml:"require,omitempty"`
 	// Assert is an object containing the conditions that the Spec will assert.
 	Assert *Expect `yaml:"assert,omitempty"`
 	// On is an object containing actions to take upon certain conditions.

--- a/plugin/exec/testdata/stop-on-fail.yaml
+++ b/plugin/exec/testdata/stop-on-fail.yaml
@@ -1,0 +1,17 @@
+name: stop-on-fail
+description: |
+    a scenario that tests that a failed assertion for a stop-on-fail
+    test spec prevents subsequent test specs from being executed.
+tests:
+  - exec: echo "meaning of life"
+    assert:
+      out:
+        is: 1234
+  # This test should be executed because we do not use the require: true.
+  - exec: echo 42
+    assert:
+      require: true
+      out:
+        is: 24
+  # This test should not be executed because of the use of require: true above
+  - exec: echo 24


### PR DESCRIPTION
Adds support for a new `assert.require` field which tells `gdt` to stop processing the rest of a test scenario when an assertion fails. The default behaviour is to continue processing the test scenario if an assertion fails.

Issue gdt-dev/gdt#66