### PR TITLE
fix conversion for int/uint in ReplaceVariables

### DIFF
--- a/context/getter.go
+++ b/context/getter.go
@@ -128,10 +128,30 @@ func ReplaceVariables(
 			dataValStr = dataVal
 		case []byte:
 			dataValStr = string(dataVal)
-		case int, uint, int8, int16, int32, int64:
-			dataValStr = strconv.Itoa(dataVal.(int))
-		case float32, float64:
-			dataValStr = strconv.FormatFloat(dataVal.(float64), 'f', -1, 64)
+		case int64:
+			dataValStr = strconv.FormatInt(dataVal, 10)
+		case int:
+			dataValStr = strconv.FormatInt(int64(dataVal), 10)
+		case int8:
+			dataValStr = strconv.FormatInt(int64(dataVal), 10)
+		case int16:
+			dataValStr = strconv.FormatInt(int64(dataVal), 10)
+		case int32:
+			dataValStr = strconv.FormatInt(int64(dataVal), 10)
+		case uint64:
+			dataValStr = strconv.FormatUint(dataVal, 10)
+		case uint:
+			dataValStr = strconv.FormatUint(uint64(dataVal), 10)
+		case uint8:
+			dataValStr = strconv.FormatUint(uint64(dataVal), 10)
+		case uint16:
+			dataValStr = strconv.FormatUint(uint64(dataVal), 10)
+		case uint32:
+			dataValStr = strconv.FormatUint(uint64(dataVal), 10)
+		case float32:
+			dataValStr = strconv.FormatFloat(float64(dataVal), 'f', -1, 64)
+		case float64:
+			dataValStr = strconv.FormatFloat(dataVal, 'f', -1, 64)
 		default:
 			continue
 		}


### PR DESCRIPTION
There was an unsafe type conversion in the type switch statement in `cotnext.ReplaceVariables()` that caused a panic that looked like this:

```
panic: interface conversion: interface {} is int64, not int

goroutine 147 [running]:
github.com/gdt-dev/core/context.ReplaceVariables({0x105cbd6c8?, 0x140007a5030?}, {0x14000042480, 0xc})
	/Users/abdul/go/pkg/mod/github.com/gdt-dev/core@v1.10.4/context/getter.go:132 +0x31c
github.com/gdt-dev/kube.(*Action).get(0x140000b2a20, {0x105cbd6c8, 0x140007a5030}, 0x14000483530, {0x1400027aab8, 0x5}, 0x14000053d00)
	/Users/abdul/go/pkg/mod/github.com/gdt-dev/kube@v1.10.3/action.go:126 +0x60
github.com/gdt-dev/kube.(*Action).Do(0x105cbd6c8?, {0x105cbd6c8?, 0x140007a5030?}, 0x1400027aab8?, {0x1400027aab8?, 0x1046819ec?}, 0x14000567cc8?)
	/Users/abdul/go/pkg/mod/github.com/gdt-dev/kube@v1.10.3/action.go:104 +0xb8
github.com/gdt-dev/kube.(*Spec).Eval(0x140000c2d80, {0x105cbd6c8, 0x140007a5030})
	/Users/abdul/go/pkg/mod/github.com/gdt-dev/kube@v1.10.3/eval.go:37 +0x1e8
github.com/gdt-dev/core/scenario.(*Scenario).execSpec(0x0?, {0x105cbd6c8, 0x140007a5030}, 0x140007a4fc0, 0x140002406c0, 0x0?, {0x105cbf320, 0x140000c2d80})
	/Users/abdul/go/pkg/mod/github.com/gdt-dev/core@v1.10.4/scenario/run.go:369 +0x3ac1
```

This patch fixes that unsafe type conversion and uses the recommended `strconv.FormatInt` and `strconv.FormatUint` functions for safe conversion of int64 and uint64 to string.

Issue gdt-dev/gdt#72